### PR TITLE
Add custom decks

### DIFF
--- a/deck/deck.go
+++ b/deck/deck.go
@@ -1,7 +1,11 @@
 // Package deck provides various deck capabilities
 package deck
 
-import "errors"
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+)
 
 // Deck represents an individual deck of cards
 type Deck struct {
@@ -24,6 +28,8 @@ var TShirtSizes = &Deck{"T-Shirt Sizes", []string{"XS", "S", "M", "L", "XL", "XX
 var Hours = &Deck{"Hours", []string{"0", ".5", "1", "2", "4", "8", "12", "16", "20", "24", "?", "☕"}}
 
 // AllDecks contains a mapping of deck names to decks
+// type Decks map[string]*Deck
+
 var AllDecks = map[string]*Deck{
 	ModifiedFibonacci.Name: ModifiedFibonacci,
 	Fibonacci.Name:         Fibonacci,
@@ -38,4 +44,21 @@ func (d *Deck) GetCard(i int) (string, error) {
 	}
 
 	return d.Cards[i], nil
+}
+
+func AppendFromJSON(filename string) (err error) {
+	newDecks := make(map[string]*Deck)
+	buf, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(buf, &newDecks)
+	if err != nil {
+		return
+	}
+	for name, deck := range AllDecks {
+		newDecks[name] = deck
+	}
+	AllDecks = newDecks
+	return
 }

--- a/decks.json
+++ b/decks.json
@@ -1,0 +1,1 @@
+{"hewwo":{"name":"hewwo","cards":["hi","uh","45","$$$"]},"UHHH":{"name":"UHHH","cards":["yes","no","maybe so","for sure"]}}

--- a/server/server.go
+++ b/server/server.go
@@ -237,6 +237,12 @@ func (s *Server) roomHandler(w http.ResponseWriter, r *http.Request) {
 
 	token = g.Token
 
+	decktest, _ := json.Marshal(deck.AllDecks)
+	fmt.Println(string(decktest))
+	err := deck.AppendFromJSON("decks.json")
+	if err != nil {
+		log.Errorf("could not unmarshal JSON: %v", err)
+	}
 	deckJSON, _ := json.Marshal(deck.AllDecks)
 
 	decks := make([]string, 0, len(deck.AllDecks))


### PR DESCRIPTION
Gives users the ability to configure their own card decks in a JSON file (`decks.json`).
This probably needs some additional Javascript/CSS work in order to make custom card decks more flexible in size.